### PR TITLE
chore(uniq-job): work around the uniq job not being

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
+gem "sidekiq"
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
+    connection_pool (2.2.5)
     crass (1.0.6)
     debug (1.4.0)
       irb (>= 1.3.6)
@@ -177,6 +178,10 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
+    sidekiq (6.4.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -224,6 +229,7 @@ DEPENDENCIES
   rails (~> 7.0.2, >= 7.0.2.3)
   redis (~> 4.0)
   selenium-webdriver
+  sidekiq
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/sidekiq/comments/mark_as_read_job.rb
+++ b/app/sidekiq/comments/mark_as_read_job.rb
@@ -1,0 +1,27 @@
+class Comments::MarkAsReadJob
+  include Sidekiq::Job
+
+  def perform(comment_id)
+    return if running?(comment_id) # Bug raise when removing this
+
+    comment = Comment.find(comment_id)
+    sleep 1
+    raise 'Already read!' if comment.reload.read?
+
+    comment.update(read: true)
+  end
+
+  def key(id)
+    "comments:mark_as_read:#{id}"
+  end
+
+  def running?(id)
+    redis do |conn|
+      conn.getset(key(id), true).present?
+    end
+  end
+
+  def redis(&block)
+    Sidekiq.redis(&block)
+  end
+end

--- a/db/migrate/20220327094445_add_read_to_comments.rb
+++ b/db/migrate/20220327094445_add_read_to_comments.rb
@@ -1,0 +1,5 @@
+class AddReadToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :read, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_26_140655) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_27_094445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_26_140655) do
     t.integer "rating"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "read", default: false
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,5 +15,5 @@ unless Comment.any?
     Comment.create(user: User.all.sample, rating: rand(1..5))
   end
 end
-
+Comment.update_all(read: false) if Comment.where(read: true).any?
 Comment.find_each { |comment| Comments::MarkAsReadJob.perform_async(comment.id) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,19 @@
-user1 = User.create(name: 'Ola')
-user2 = User.create(name: 'Hello')
-user3 = User.create(name: 'Wow')
-User.create(name: 'Bye')
+unless User.any?
+  user1 = User.create(name: 'Ola')
+  user2 = User.create(name: 'Hello')
+  user3 = User.create(name: 'Wow')
+  User.create(name: 'Bye')
+end
 
-Comment.create(user: user1, rating: 1)
-Comment.create(user: user2, rating: 5)
-Comment.create(user: user2, rating: 3)
-Comment.create(user: user3, rating: 5)
-Comment.create(user: user1, rating: 2)
+unless Comment.any?
+  Comment.create(user: user1, rating: 1)
+  Comment.create(user: user2, rating: 5)
+  Comment.create(user: user2, rating: 3)
+  Comment.create(user: user3, rating: 5)
+  Comment.create(user: user1, rating: 2)
+  1000.times do
+    Comment.create(user: User.all.sample, rating: rand(1..5))
+  end
+end
+
+Comment.find_each { |comment| Comments::MarkAsReadJob.perform_async(comment.id) }

--- a/test/sidekiq/comments/mark_as_read_job_test.rb
+++ b/test/sidekiq/comments/mark_as_read_job_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+class Comments::MarkAsReadJobTest < Minitest::Test
+  def test_example
+    skip "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Add the lock to ignore the enqueued job.
remove this [line](https://github.com/dthtien/recent_issue/pull/1/files#diff-8d5a897cb7ecd4e1447cad7b054d19543bcd3e0029210861eab3af90f40fe15cR5) to replicate the duplicated enqueued jobs `rails db:seed`